### PR TITLE
fix(dataloader): prevent loaded_block corruption from a bogus 0 chain…

### DIFF
--- a/mystiko_core/src/handler/deposit/asset.rs
+++ b/mystiko_core/src/handler/deposit/asset.rs
@@ -100,7 +100,7 @@ where
         Signer: TransactionSigner + 'static,
     {
         let mut tx_hashes = vec![];
-        for (_, asset_context) in assets_context.iter() {
+        for asset_context in assets_context.values() {
             if let Some(tx_hash) = self
                 .asset_approve(context, asset_context, options, signer.clone(), owner)
                 .await?

--- a/mystiko_dataloader/src/fetcher/etherscan.rs
+++ b/mystiko_dataloader/src/fetcher/etherscan.rs
@@ -21,6 +21,8 @@ pub const ETHERSCAN_FETCHER_NAME: &str = "etherscan";
 pub enum EtherscanFetcherError {
     #[error("etherscan fetcher no chain config found for chain id: {0}")]
     UnsupportedChainError(u64),
+    #[error("etherscan fetcher invalid current block 0 for chain id: {0}")]
+    InvalidCurrentBlock(u64),
 }
 
 #[derive(Debug, TypedBuilder)]
@@ -108,6 +110,14 @@ where
             .await
             .map_err(|err| FetcherError::AnyhowError(err.into()))?
             .as_u64();
+        // A live chain's head can never be block 0; a client reporting 0 is a bogus/failover
+        // response. Reject the raw head (before the delay subtraction) so this round fails fast
+        // instead of collapsing the fetch target to 0 and persisting a corrupt loaded_block.
+        if current_block == 0 {
+            return Err(FetcherError::AnyhowError(
+                EtherscanFetcherError::InvalidCurrentBlock(chain_id).into(),
+            ));
+        }
         let current_safe_block = current_block.saturating_sub(delay_num_blocks);
         Ok((current_safe_block, client))
     }

--- a/mystiko_dataloader/src/fetcher/provider.rs
+++ b/mystiko_dataloader/src/fetcher/provider.rs
@@ -47,6 +47,8 @@ pub enum ProviderFetcherError {
     ProviderError(#[from] ProviderError),
     #[error("unsupported chain id: {0}")]
     UnsupportedChainError(u64),
+    #[error("invalid current block 0 for chain id: {0}")]
+    InvalidCurrentBlock(u64),
 }
 
 pub const DEFAULT_MAX_REQUESTS_PER_SECOND: u32 = 5;
@@ -183,6 +185,14 @@ where
             .await
             .map_err(FetcherError::AnyhowError)?
             .as_u64();
+        // A live chain's head can never be block 0; a provider reporting 0 is a bogus/failover
+        // response. Reject the raw head (before the delay subtraction) so this round fails fast
+        // instead of collapsing the fetch target to 0 and persisting a corrupt loaded_block.
+        if current_block == 0 {
+            return Err(FetcherError::AnyhowError(
+                ProviderFetcherError::InvalidCurrentBlock(chain_id).into(),
+            ));
+        }
         let current_safe_block = current_block.saturating_sub(delay_num_blocks);
         Ok((current_safe_block, provider))
     }

--- a/mystiko_dataloader/src/handler/database/mod.rs
+++ b/mystiko_dataloader/src/handler/database/mod.rs
@@ -422,7 +422,11 @@ where
                         .build()
                 }
             };
-            contract.data.update_loaded_block(contract_data.end_block);
+            // loaded_block must only advance here: a transient bad fetch (e.g. a provider
+            // reporting head 0) can carry an end_block below the stored value, and regressing
+            // it would force a full re-scan. Reset lowers it deliberately via a different path.
+            let new_loaded_block = std::cmp::max(contract.data.get_loaded_block(), contract_data.end_block);
+            contract.data.update_loaded_block(new_loaded_block);
             contract.updated_at = current_timestamp();
             self.upsert_contract_data(contract_update, &contract).await?;
         }

--- a/mystiko_dataloader/tests/fetcher/etherscan_tests.rs
+++ b/mystiko_dataloader/tests/fetcher/etherscan_tests.rs
@@ -544,6 +544,39 @@ async fn test_chain_loaded_block() {
 }
 
 #[tokio::test]
+async fn test_chain_loaded_block_zero_current_block() {
+    // A client that reports head block 0 (a bogus failover response) must cause
+    // chain_loaded_block to error rather than return a 0/near-0 safe block.
+    let mut mocked_server = mockito::Server::new_async().await;
+    let test_chain_id = 1u64;
+    let test_api_key = "test_api_key";
+    let path = mocked_server
+        .mock("GET", "/api")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("action".into(), "eth_blockNumber".into()),
+            Matcher::UrlEncoded("apikey".into(), test_api_key.into()),
+            Matcher::UrlEncoded("module".into(), "proxy".into()),
+        ]))
+        .with_status(200)
+        .with_body("{\"jsonrpc\": \"2.0\",\"id\": 1,\"result\": \"0x0\"}")
+        .with_header("content-type", "application/json")
+        .create_async()
+        .await;
+    let etherscan_fetcher =
+        build_etherscan_fetcher::<LiteData>(&mocked_server.url(), test_chain_id, 1000u64, test_api_key, 1u32);
+    let config = Arc::new(
+        MystikoConfig::from_json_file("tests/files/config/mystiko.json")
+            .await
+            .unwrap(),
+    );
+    let options = ChainLoadedBlockOptions::builder().chain_id(1u64).config(config).build();
+    let result = etherscan_fetcher.chain_loaded_block(&options).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("invalid current block"));
+    path.assert_async().await;
+}
+
+#[tokio::test]
 async fn test_chain_loaded_block_with_delay() {
     let mut mocked_server = mockito::Server::new_async().await;
     let test_api_key = "test_api_key";

--- a/mystiko_dataloader/tests/fetcher/provider_tests.rs
+++ b/mystiko_dataloader/tests/fetcher/provider_tests.rs
@@ -27,6 +27,8 @@ impl Providers for TestProvders {
             Ok(Arc::new(mock_chain_56(test_provider)))
         } else if chain_id == 1 {
             Ok(Arc::new(mock_chain_1(test_provider)))
+        } else if chain_id == 8453 {
+            Ok(Arc::new(mock_chain_zero_head(test_provider)))
         } else {
             Ok(Arc::new(mock_chain_5(test_provider)))
         }
@@ -565,6 +567,26 @@ async fn test_chain_loaded_block_too_big_delay() {
     assert_eq!(provider_fetcher.chain_loaded_block(&options).await.unwrap(), 0u64);
 }
 
+#[tokio::test]
+async fn test_chain_loaded_block_zero_current_block() {
+    // A provider that reports head block 0 (a bogus failover response) must cause
+    // chain_loaded_block to error rather than return a 0/near-0 safe block, which
+    // would otherwise collapse the fetch target and corrupt the stored loaded_block.
+    let provider_fetcher: ProviderFetcher<LiteData, TestProvders> = Arc::new(TestProvders).into();
+    let mystiko_config = Arc::new(
+        MystikoConfig::from_json_file("./tests/files/config/mystiko.json")
+            .await
+            .unwrap(),
+    );
+    let options = ChainLoadedBlockOptions::builder()
+        .chain_id(8453u64)
+        .config(mystiko_config.clone())
+        .build();
+    let result = provider_fetcher.chain_loaded_block(&options).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("invalid current block"));
+}
+
 #[derive(Debug, Default)]
 struct MockProviderRetryPolicy;
 
@@ -772,6 +794,13 @@ fn mock_chain_5(test_provider: MockProvider) -> Provider {
     // current_block_num
     test_provider.push(U64::from(8896966)).unwrap();
 
+    create_mock_provider(&test_provider)
+}
+
+fn mock_chain_zero_head(test_provider: MockProvider) -> Provider {
+    // eth_blockNumber returns 0, simulating a flaky/failover RPC endpoint that
+    // reports an impossible head block for a live chain.
+    test_provider.push(U64::from(0)).unwrap();
     create_mock_provider(&test_provider)
 }
 

--- a/mystiko_dataloader/tests/handler/database/handler_tests.rs
+++ b/mystiko_dataloader/tests/handler/database/handler_tests.rs
@@ -993,6 +993,68 @@ async fn test_full_data_handle() {
 }
 
 #[tokio::test]
+async fn test_handle_does_not_lower_loaded_block() {
+    // Regression guard: a transient bad fetch (e.g. a provider reporting head 0)
+    // can carry an end_block below the contract's stored loaded_block. Handling it
+    // must never regress loaded_block, which would force a full re-scan.
+    let (database_handler, collection, _config) = setup::<FullData>().await.unwrap();
+    let mock_contracts = [Contract {
+        chain_id: 1_u64,
+        contract_address: "address1".to_string(),
+        loaded_block: 2000_u64,
+    }];
+    collection.insert_batch(&mock_contracts).await.unwrap();
+
+    // A bogus empty fetch whose end_block (0) is below the stored loaded_block (2000).
+    let regressing_chain_data = ChainData::builder()
+        .chain_id(1_u64)
+        .contracts_data(vec![ContractData::builder()
+            .address("address1")
+            .start_block(0_u64)
+            .end_block(0_u64)
+            .data(FullData::builder().commitments(vec![]).nullifiers(vec![]).build())
+            .build()])
+        .build();
+    let config = Arc::new(
+        MystikoConfig::from_json_file("./tests/files/handler/config.json")
+            .await
+            .unwrap(),
+    );
+    let handle_result = database_handler
+        .handle(
+            &regressing_chain_data,
+            &HandleOption::builder().config(config.clone()).build(),
+        )
+        .await;
+    assert!(handle_result.is_ok());
+    let loaded_block = database_handler
+        .query_contract_loaded_block(1_u64, "address1")
+        .await
+        .unwrap();
+    assert_eq!(loaded_block, Some(2000_u64));
+
+    // A legitimate fetch whose end_block (3000) is above the stored loaded_block advances it.
+    let advancing_chain_data = ChainData::builder()
+        .chain_id(1_u64)
+        .contracts_data(vec![ContractData::builder()
+            .address("address1")
+            .start_block(2000_u64)
+            .end_block(3000_u64)
+            .data(FullData::builder().commitments(vec![]).nullifiers(vec![]).build())
+            .build()])
+        .build();
+    let handle_result = database_handler
+        .handle(&advancing_chain_data, &HandleOption::builder().config(config).build())
+        .await;
+    assert!(handle_result.is_ok());
+    let loaded_block = database_handler
+        .query_contract_loaded_block(1_u64, "address1")
+        .await
+        .unwrap();
+    assert_eq!(loaded_block, Some(3000_u64));
+}
+
+#[tokio::test]
 async fn test_lite_data_handle() {
     let (database_handler, collection, _config) = setup::<LiteData>().await.unwrap();
     let mock_contracts = [

--- a/mystiko_dataloader/tests/loader/mock/loader_mock.rs
+++ b/mystiko_dataloader/tests/loader/mock/loader_mock.rs
@@ -181,7 +181,7 @@ pub fn contract_data_partial_eq(a: &HashMap<String, ContractData<FullData>>, b: 
                 return false;
             }
         } else {
-            println!("Address not found: {}", &d.address);
+            println!("Address not found: {}", d.address);
             return false;
         }
     }

--- a/mystiko_etherscan_client/src/client.rs
+++ b/mystiko_etherscan_client/src/client.rs
@@ -122,7 +122,7 @@ impl EtherScanClient {
         let mut params: Vec<String> = vec![];
         params.push("action=eth_call".to_string());
         params.push("module=proxy".to_string());
-        params.push(format!("apikey={}", &self.api_key));
+        params.push(format!("apikey={}", self.api_key));
         params.push(format!("to={}", to));
         params.push(format!("data={}", function_encoded_data));
         params.push(format!("tag={}", block_tag.unwrap_or("latest")));
@@ -141,7 +141,7 @@ impl EtherScanClient {
         let mut params: Vec<String> = vec![];
         params.push("action=eth_blockNumber".to_string());
         params.push("module=proxy".to_string());
-        params.push(format!("apikey={}", &self.api_key));
+        params.push(format!("apikey={}", self.api_key));
         let url = self.format_url(&params);
         let options = GetOptions::<String>::builder()
             .url(url)
@@ -160,7 +160,7 @@ impl EtherScanClient {
         params.push("action=eth_getBlockByNumber".to_string());
         params.push("module=proxy".to_string());
         params.push("boolean=false".to_string());
-        params.push(format!("apikey={}", &self.api_key));
+        params.push(format!("apikey={}", self.api_key));
         params.push(format!("tag={:x}", block_number));
         let url = self.format_url(&params);
         let options = GetOptions::<String>::builder()
@@ -175,7 +175,7 @@ impl EtherScanClient {
         params.push("action=eth_getTransactionByHash".to_string());
         params.push("module=proxy".to_string());
         params.push(format!("txhash={}", transaction_hash));
-        params.push(format!("apikey={}", &self.api_key));
+        params.push(format!("apikey={}", self.api_key));
         let url = self.format_url(&params);
         let options = GetOptions::<String>::builder()
             .url(url)
@@ -189,7 +189,7 @@ impl EtherScanClient {
         params.push("action=eth_getTransactionReceipt".to_string());
         params.push("module=proxy".to_string());
         params.push(format!("txhash={}", transaction_hash));
-        params.push(format!("apikey={}", &self.api_key));
+        params.push(format!("apikey={}", self.api_key));
         let url = self.format_url(&params);
         let options = GetOptions::<String>::builder()
             .url(url)
@@ -213,10 +213,10 @@ impl EtherScanClient {
         params.push("module=logs".to_string());
         params.push("page=1".to_string());
         params.push(format!("toBlock={}", options.to_block));
-        params.push(format!("offset={}", &self.offset));
+        params.push(format!("offset={}", self.offset));
         params.push(format!("address={}", options.address));
         params.push(format!("topic0=0x{:x}", R::signature()));
-        params.push(format!("apikey={}", &self.api_key));
+        params.push(format!("apikey={}", self.api_key));
         #[allow(clippy::mutable_key_type)]
         let mut raw_logs = HashSet::new();
         let mut events: Vec<Event<R>> = Vec::new();

--- a/mystiko_etherscan_client/tests/client_tests.rs
+++ b/mystiko_etherscan_client/tests/client_tests.rs
@@ -644,7 +644,7 @@ async fn test_failed_for_max_rate_limit_reached() {
     let options = GetOptions::<String>::builder()
         .url(format!(
             "{}/api?module=normal&apikey=test_api_key",
-            &ether_scan_client.base_url
+            ether_scan_client.base_url
         ))
         .module(EtherScanModule::Normal)
         .build();
@@ -675,7 +675,7 @@ async fn test_failed_for_max_rate_limit_reached() {
     let options = GetOptions::<String>::builder()
         .url(format!(
             "{}/api?module=proxy&apikey=test_api_key",
-            &ether_scan_client.base_url
+            ether_scan_client.base_url
         ))
         .module(EtherScanModule::JsonRpcProxy)
         .build();
@@ -717,7 +717,7 @@ async fn test_handle_response_failed_for_content_type() {
     let options = GetOptions::<String>::builder()
         .url(format!(
             "{}/api?module=proxy&apikey=test_api_key",
-            &ether_scan_client.base_url
+            ether_scan_client.base_url
         ))
         .module(EtherScanModule::JsonRpcProxy)
         .build();
@@ -745,7 +745,7 @@ async fn test_handle_response_failed_for_content_type() {
     let options = GetOptions::<String>::builder()
         .url(format!(
             "{}/api?module=proxy&apikey=test_api_key",
-            &ether_scan_client.base_url
+            ether_scan_client.base_url
         ))
         .module(EtherScanModule::JsonRpcProxy)
         .build();
@@ -791,7 +791,7 @@ async fn test_handle_response_failed_for_json_rpc_error() {
     let options = GetOptions::<String>::builder()
         .url(format!(
             "{}/api?module=proxy&apikey=test_api_key",
-            &ether_scan_client.base_url
+            ether_scan_client.base_url
         ))
         .module(EtherScanModule::JsonRpcProxy)
         .build();
@@ -841,7 +841,7 @@ async fn test_handle_logs_with_empty_response() {
     let options = GetOptions::<String>::builder()
         .url(format!(
             "{}/api?module=logs&apikey=test_api_key&action=getLogs&address=address&fromBlock=12878100&toBlock=12878100",
-            &ether_scan_client.base_url
+            ether_scan_client.base_url
         ))
         .module(EtherScanModule::Normal)
         .build();

--- a/mystiko_protos/src/lib.rs
+++ b/mystiko_protos/src/lib.rs
@@ -2,6 +2,7 @@
 #[allow(clippy::needless_borrows_for_generic_args)]
 #[allow(clippy::empty_docs)]
 #[allow(clippy::needless_lifetimes)]
+#[allow(clippy::useless_borrows_in_formatting)]
 mod gen;
 
 pub mod api;

--- a/mystiko_storage/src/formatter/sql.rs
+++ b/mystiko_storage/src/formatter/sql.rs
@@ -241,7 +241,7 @@ impl StatementFormatter for SqlStatementFormatter {
     ) -> Result<Statement, StorageError> {
         let fields = Document::<T>::columns()
             .iter()
-            .map(|column| format!("`{}`", &column.column_name))
+            .map(|column| format!("`{}`", column.column_name))
             .collect::<Vec<String>>();
         let statement = match filter_option {
             Some(filter) => {


### PR DESCRIPTION
… head

A flaky Base (8453) RPC endpoint intermittently returned eth_blockNumber=0x0. Under failover that 0 was trusted, collapsing the fetch target to block 0 (from_block > to_block=0 -> empty fetch), and the handler then persisted end_block=0, regressing the contract loaded_block from ~chain head to 0 and forcing a full re-scan.

D2 (fix): handle_contract_data now advances loaded_block only (max(existing, end_block)), so a low/zero end_block can never regress persisted progress. The reset path (update_by_filter) is unaffected.

D1 (defense-in-depth): provider and etherscan chain_safe_current_block now error (InvalidCurrentBlock) when the raw head is 0 -- a live chain's head is never block 0 -- before the delay subtraction, so a bogus 0 fails the round fast instead of producing a corrupt empty fetch.

Tests: zero-head provider mock, mockito 0x0 etherscan response, and a handler test proving end_block=0 keeps loaded_block=2000 (pre-fix returned 0) while a later end_block=3000 still advances.